### PR TITLE
Fix class name in functional tests templates

### DIFF
--- a/src/tests/gate-basic-trusty-icehouse
+++ b/src/tests/gate-basic-trusty-icehouse
@@ -16,8 +16,8 @@
 
 """Amulet tests on a basic SDN Charm deployment on trusty-icehouse."""
 
-from basic_deployment import SDNCharmDeployment
+from basic_deployment import {{ charm_class }}Deployment
 
 if __name__ == '__main__':
-    deployment = SDNCharmDeployment(series='trusty')
+    deployment = {{ charm_class }}Deployment(series='trusty')
     deployment.run_tests()

--- a/src/tests/gate-basic-trusty-liberty
+++ b/src/tests/gate-basic-trusty-liberty
@@ -16,10 +16,10 @@
 
 """Amulet tests on a basic SDN Charm deployment on trusty-liberty."""
 
-from basic_deployment import SDNCharmDeployment
+from basic_deployment import {{ charm_class }}Deployment
 
 if __name__ == '__main__':
-    deployment = SDNCharmDeployment(series='trusty',
+    deployment = {{ charm_class }}Deployment(series='trusty',
                                     openstack='cloud:trusty-liberty',
                                     source='cloud:trusty-updates/liberty')
     deployment.run_tests()

--- a/src/tests/gate-basic-trusty-mitaka
+++ b/src/tests/gate-basic-trusty-mitaka
@@ -16,10 +16,10 @@
 
 """Amulet tests on a basic SDN Charm deployment on trusty-mitaka."""
 
-from basic_deployment import SDNCharmDeployment
+from basic_deployment import {{ charm_class }}Deployment
 
 if __name__ == '__main__':
-    deployment = SDNCharmDeployment(series='trusty',
+    deployment = {{ charm_class }}Deployment(series='trusty',
                                     openstack='cloud:trusty-mitaka',
                                     source='cloud:trusty-updates/mitaka')
     deployment.run_tests()


### PR DESCRIPTION
Currently, the functional tests reference an SDNCharmDeployment class in
three of the four provided functional tests templates.

This commit uses the actual class name in all of the functional tests
templates. This allows running the tests out of the box without having to
edit the files.